### PR TITLE
Corrected autoload setting in `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "FontLib\\": "src/"
+        "psr-4": {
+            "FontLib\\": "src/FontLib"
         }
     }
 }


### PR DESCRIPTION
Underscores are namespace separators in PSR-0. This project conforms to PSR-4 and not PSR-0.