### PR TITLE
Use the multi-read helpers to reduce big font parsing time by ~40%

### DIFF
--- a/src/FontLib/Table/Type/cmap.php
+++ b/src/FontLib/Table/Type/cmap.php
@@ -64,15 +64,15 @@ class cmap extends Table {
       $segCount             = $subtable["segCountX2"] / 2;
       $subtable["segCount"] = $segCount;
 
-      $endCode = $font->r(array(self::uint16, $segCount));
+      $endCode = $font->readUInt16Many($segCount);
 
       $font->readUInt16(); // reservedPad
 
-      $startCode = $font->r(array(self::uint16, $segCount));
-      $idDelta   = $font->r(array(self::int16, $segCount));
+      $startCode = $font->readUInt16Many($segCount);
+      $idDelta   = $font->readInt16Many($segCount);
 
       $ro_start      = $font->pos();
-      $idRangeOffset = $font->r(array(self::uint16, $segCount));
+      $idRangeOffset = $font->readUInt16Many($segCount);
 
       $glyphIndexArray = array();
       for ($i = 0; $i < $segCount; $i++) {

--- a/src/FontLib/Table/Type/hmtx.php
+++ b/src/FontLib/Table/Type/hmtx.php
@@ -25,9 +25,10 @@ class hmtx extends Table {
     $font->seek($offset);
 
     $data = array();
-    for ($gid = 0; $gid < $numOfLongHorMetrics; $gid++) {
-      $advanceWidth    = $font->readUInt16();
-      $leftSideBearing = $font->readUInt16();
+    $metrics = $font->readUInt16Many($numOfLongHorMetrics * 2);
+    for ($gid = 0, $mid = 0; $gid < $numOfLongHorMetrics; $gid++) {
+      $advanceWidth    = $metrics[$mid++];
+      $leftSideBearing = $metrics[$mid++];
       $data[$gid]      = array($advanceWidth, $leftSideBearing);
     }
 

--- a/src/FontLib/Table/Type/kern.php
+++ b/src/FontLib/Table/Type/kern.php
@@ -44,10 +44,15 @@ class kern extends Table {
         $pairs = array();
         $tree  = array();
 
-        for ($i = 0; $i < $subtable["nPairs"]; $i++) {
-          $left  = $font->readUInt16();
-          $right = $font->readUInt16();
-          $value = $font->readInt16();
+        $values = $font->readUInt16Many($subtable["nPairs"] * 3);
+        for ($i = 0, $idx = 0; $i < $subtable["nPairs"]; $i++) {
+          $left  = $values[$idx++];
+          $right = $values[$idx++];
+          $value = $values[$idx++];
+
+          if ($value >= 0x8000) {
+            $value -= 0x10000;
+          }
 
           $pairs[] = array(
             "left"  => $left,

--- a/src/FontLib/Table/Type/post.php
+++ b/src/FontLib/Table/Type/post.php
@@ -42,10 +42,7 @@ class post extends Table {
       case 2:
         $data["numberOfGlyphs"] = $font->readUInt16();
 
-        $glyphNameIndex = array();
-        for ($i = 0; $i < $data["numberOfGlyphs"]; $i++) {
-          $glyphNameIndex[] = $font->readUInt16();
-        }
+        $glyphNameIndex = $font->readUInt16Many($data["numberOfGlyphs"]);
 
         $data["glyphNameIndex"] = $glyphNameIndex;
 


### PR DESCRIPTION
When loading the FreeSerif font, BinaryStream->read calls went down from 105954 to 42762, readUInt16 calls went from 74220 to 11025, readInt16 calls went from 21112 to 10585.
Overall the loading time was reduced by 40%