### PR TITLE
Final patch of optimizations, giving additional 20% speedup

### DIFF
--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -210,7 +210,8 @@ class BinaryStream {
   }
 
   public function readInt16() {
-    $v = $this->readUInt16();
+    $a = unpack("nn", $this->read(2));
+    $v = $a["n"];
 
     if ($v >= 0x8000) {
       $v -= 0x10000;

--- a/src/FontLib/Glyph/Outline.php
+++ b/src/FontLib/Glyph/Outline.php
@@ -42,8 +42,7 @@ class Outline extends BinaryStream {
    *
    * @return Outline
    */
-  static function init(glyf $table, $offset, $size) {
-    $font = $table->getFont();
+  static function init(glyf $table, $offset, $size, BinaryStream $font) {
     $font->seek($offset);
 
     if ($font->readInt16() > -1) {
@@ -55,7 +54,7 @@ class Outline extends BinaryStream {
       $glyph = new OutlineComposite($table, $offset, $size);
     }
 
-    $glyph->parse();
+    $glyph->parse($font);
 
     return $glyph;
   }
@@ -73,8 +72,7 @@ class Outline extends BinaryStream {
     $this->size   = $size;
   }
 
-  function parse() {
-    $font = $this->getFont();
+  function parse(BinaryStream $font) {
     $font->seek($this->offset);
 
     if (!$this->size) {

--- a/src/FontLib/Table/Type/glyf.php
+++ b/src/FontLib/Table/Type/glyf.php
@@ -31,7 +31,7 @@ class glyf extends Table {
     foreach ($real_loca as $gid => $location) {
       $_offset    = $offset + $loca[$gid];
       $_size      = $loca[$gid + 1] - $loca[$gid];
-      $data[$gid] = Outline::init($this, $_offset, $_size);
+      $data[$gid] = Outline::init($this, $_offset, $_size, $font);
     }
 
     $this->data = $data;


### PR DESCRIPTION
This should be the last part of the parsing optimizations, overall speedup on my machine (Win10, PHP 5.5) for loading FreeSerif font is now ~55%, 1.3s => 0.65s.