### PR TITLE
Fixes an "Undefined offset: 1" PHP Notice.

### DIFF
--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -411,7 +411,9 @@ class BinaryStream {
 
           $ret = 0;
           for ($i = 0; $i < $type[1]; $i++) {
-            $ret += $this->w($type[0], $data[$i]);
+            if (isset($data[$i])) {
+              $ret += $this->w($type[0], $data[$i]);
+            }
           }
 
           return $ret;


### PR DESCRIPTION
When using DejaVu Sans or any @font-face font, this would always throw PHP errors in my app. It makes sense to check if it's set to prevent the notice. Ideally, though, this shouldn't even be throwing errors, but I don't know enough about php-font-lib's code to figure out what is going on.

Here's a minimal test case HTML that causes the error: http://i.28hours.org/files/php-font-lib-undefined-offset.html
