### PR TITLE
Fixes "strftime() expects parameter 2 to be integer, float given" PHP Warning.

### DIFF
--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -274,6 +274,12 @@ class BinaryStream {
     $this->readUInt32(); // ignored
     $date = $this->readUInt32() - 2082844800;
 
+    if ($date > PHP_INT_MAX) {
+      $date = PHP_INT_MAX;
+    } elseif ($date < PHP_INT_MIN) {
+      $date = PHP_INT_MIN;
+    }
+
     return strftime("%Y-%m-%d %H:%M:%S", $date);
   }
 


### PR DESCRIPTION
When using DejaVu Sans in dompdf on a 32-bit system, `$this->readUInt32();` would often return values outside of the valid integer range, which would turn them into floats, which `strftime` doesn't like. 64-bit systems don't have this problem.

This code just overrides that for values outside of the valid integer range. It doesn't solve the problem, but readLongDateTime() seems like it has very little use and in these circumstances I'd rather it return an invalid date/time than throw a PHP error. Thoughts?