### PR TITLE
Add PHP 5.6, 7.0 and HHVM to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,15 @@ env:
 php:
     - 5.4
     - 5.5
+    - 5.6
+    - 7.0
+    - hhvm
 
+matrix:
+  allow_failures:
+    - php: hhvm
+  fast_finish: true
+  
 before_script:
     - composer dump-autoload
     - composer self-update


### PR DESCRIPTION
Allow HHVM to fail, but 5.6 and 7 should be checked.