### PR TITLE
Fixes "strftime() expects parameter 2 to be integer, string given" PHP Warning, and PHP <7 compatibility issue.

### DIFF
--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -275,10 +275,8 @@ class BinaryStream {
     $this->readUInt32(); // ignored
     $date = $this->readUInt32() - 2082844800;
 
-    if ($date > PHP_INT_MAX) {
-      $date = PHP_INT_MAX;
-    } elseif ($date < PHP_INT_MIN) {
-      $date = PHP_INT_MIN;
+    if (is_string($date) || $date > PHP_INT_MAX || $date < PHP_INT_MIN) {
+      $date = 0;
     }
 
     return strftime("%Y-%m-%d %H:%M:%S", $date);

--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -274,8 +274,11 @@ class BinaryStream {
   public function readLongDateTime() {
     $this->readUInt32(); // ignored
     $date = $this->readUInt32() - 2082844800;
+    
+    # PHP_INT_MIN isn't defined in PHP < 7.0
+    $php_int_min = defined("PHP_INT_MIN") ? PHP_INT_MIN : ~PHP_INT_MAX;
 
-    if (is_string($date) || $date > PHP_INT_MAX || $date < PHP_INT_MIN) {
+    if (is_string($date) || $date > PHP_INT_MAX || $date < $php_int_min) {
       $date = 0;
     }
 


### PR DESCRIPTION
As mentioned in PR #43 there was another warning, when the int being read was a string, and not just a float (which is what #43 fixed). Additionally, the fix uses PHP_INT_MIN, which I didn't realise only exists in PHP 7. I didn't notice it because I'm running it, but I did when I tested in other versions of PHP.