### PR TITLE
'Undefined offset:' notices in loca and htmx classes

### DIFF
--- a/src/FontLib/Table/Type/hmtx.php
+++ b/src/FontLib/Table/Type/hmtx.php
@@ -27,8 +27,10 @@ class hmtx extends Table {
     $data = array();
     $metrics = $font->readUInt16Many($numOfLongHorMetrics * 2);
     for ($gid = 0, $mid = 0; $gid < $numOfLongHorMetrics; $gid++) {
-      $advanceWidth    = $metrics[$mid++];
-      $leftSideBearing = $metrics[$mid++];
+      $advanceWidth    = isset($metrics[$mid]) ? $metrics[$mid] : 0;
+      $mid += 1;
+      $leftSideBearing = isset($metrics[$mid]) ? $metrics[$mid] : 0;
+      $mid += 1;
       $data[$gid]      = array($advanceWidth, $leftSideBearing);
     }
 

--- a/src/FontLib/Table/Type/loca.php
+++ b/src/FontLib/Table/Type/loca.php
@@ -32,7 +32,7 @@ class loca extends Table {
       $loc = unpack("n*", $d);
 
       for ($i = 0; $i <= $numGlyphs; $i++) {
-        $data[] = $loc[$i + 1] * 2;
+        $data[] = isset($loc[$i + 1]) ?  $loc[$i + 1] * 2 : 0;
       }
     }
 
@@ -43,7 +43,7 @@ class loca extends Table {
         $loc = unpack("N*", $d);
 
         for ($i = 0; $i <= $numGlyphs; $i++) {
-          $data[] = $loc[$i + 1];
+          $data[] = isset($loc[$i + 1]) ? $loc[$i + 1] : 0;
         }
       }
     }


### PR DESCRIPTION
In the test suite of a Drupal module that uses this library (https://www.drupal.org/pift-ci-job/610235), I am getting a lot of PHP notices for undefined offset like 

```
exception: [Notice] Line 46 of vendor/phenx/php-font-lib/src/FontLib/Table/Type/loca.php:
Undefined offset: 2144
....
exception: [Notice] Line 30 of vendor/phenx/php-font-lib/src/FontLib/Table/Type/hmtx.php:
Undefined offset: 5332

exception: [Notice] Line 31 of vendor/phenx/php-font-lib/src/FontLib/Table/Type/hmtx.php:
Undefined offset: 5333
```

I am not sure how to fix this, but checking the existence of the array element seems to me a right thing to do anyway