### PR TITLE
Prevents PHP from throwing warnings while autoloaders include files

### DIFF
--- a/src/FontLib/TrueType/File.php
+++ b/src/FontLib/TrueType/File.php
@@ -305,7 +305,7 @@ class File extends BinaryStream {
 
       $class = "FontLib\\Table\\Type\\$name_canon";
 
-      if (!isset($this->directory[$tag]) || !class_exists($class)) {
+      if (!isset($this->directory[$tag]) || !@class_exists($class)) {
         return;
       }
     }


### PR DESCRIPTION
Prevents PHP from throwing a warning while autoloaders try to include non existing class files.
In some environments (like magento) warnings cause the application to throw an error showing an error page when development mode is used.