### PR TITLE
Emit no notices on PHP 7.4

### DIFF
--- a/src/FontLib/AdobeFontMetrics.php
+++ b/src/FontLib/AdobeFontMetrics.php
@@ -139,7 +139,7 @@ class AdobeFontMetrics {
       $this->endSection("CharMetrics");
 
       $kern = $font->getData("kern", "subtable");
-      $tree = $kern["tree"];
+      $tree = is_array($kern) ? $kern["tree"] : null;
 
       if (!$encoding && is_array($tree)) {
         $this->startSection("KernData");

--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -145,7 +145,7 @@ class BinaryStream {
     }
 
       /** @noinspection PhpUsageOfSilenceOperatorInspection - handle the return data, DO NOT spew E_NOTICEs */
-      return @fread($this->f, $n);
+    return @fread($this->f, $n);
   }
 
   public function write($data, $length = null) {

--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -38,16 +38,18 @@ class BinaryStream {
   const modeReadWrite = "rb+";
 
   static function backtrace() {
-    var_dump(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
+      /** @noinspection ForgottenDebugOutputInspection */
+      var_dump(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
   }
 
-  /**
-   * Open a font file in read mode
-   *
-   * @param string $filename The file name of the font to open
-   *
-   * @return bool
-   */
+    /**
+     * Open a font file in read mode
+     *
+     * @param string $filename The file name of the font to open
+     *
+     * @return bool
+     * @throws \Exception
+     */
   public function load($filename) {
     return $this->open($filename, self::modeRead);
   }
@@ -142,7 +144,8 @@ class BinaryStream {
       return "";
     }
 
-    return fread($this->f, $n);
+      /** @noinspection PhpUsageOfSilenceOperatorInspection - handle the return data, DO NOT spew E_NOTICEs */
+      return @fread($this->f, $n);
   }
 
   public function write($data, $length = null) {
@@ -150,7 +153,8 @@ class BinaryStream {
       return 0;
     }
 
-    return fwrite($this->f, $data, $length);
+      /** @noinspection PhpUsageOfSilenceOperatorInspection - handle the return data, DO NOT spew E_NOTICEs */
+    return @fwrite($this->f, $data, $length);
   }
 
   public function readUInt8() {

--- a/src/FontLib/BinaryStream.php
+++ b/src/FontLib/BinaryStream.php
@@ -38,7 +38,6 @@ class BinaryStream {
   const modeReadWrite = "rb+";
 
   static function backtrace() {
-      /** @noinspection ForgottenDebugOutputInspection */
       var_dump(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
   }
 
@@ -144,7 +143,7 @@ class BinaryStream {
       return "";
     }
 
-      /** @noinspection PhpUsageOfSilenceOperatorInspection - handle the return data, DO NOT spew E_NOTICEs */
+    // handle the return data, DO NOT spew E_NOTICEs
     return @fread($this->f, $n);
   }
 
@@ -153,7 +152,7 @@ class BinaryStream {
       return 0;
     }
 
-      /** @noinspection PhpUsageOfSilenceOperatorInspection - handle the return data, DO NOT spew E_NOTICEs */
+    // handle the return data, DO NOT spew E_NOTICEs
     return @fwrite($this->f, $data, $length);
   }
 


### PR DESCRIPTION
fread() and fwrite() may emit E_NOTICE as seen in https://bugs.php.net/bug.php?id=78482
This is apparently by-design, but the resulting ErrorException propagates all the way up the stack, crashing the application.
Building on #76 , silence this notice - as the condition is still indicated by the return value, there's no point in emitting it.