### PR TITLE
'Undefined offset:' notices in post classes

### DIFF
--- a/src/FontLib/Table/Type/post.php
+++ b/src/FontLib/Table/Type/post.php
@@ -57,7 +57,7 @@ class post extends Table {
             $names[$g] = File::$macCharNames[$index];
           }
           else {
-            $names[$g] = $namesPascal[$index - 258];
+            $names[$g] = isset($namesPascal[$index - 258]) ? $namesPascal[$index - 258] : 0;
           }
         }
 


### PR DESCRIPTION
Error depending on font used when using Laravel dom pdf
The issue that has been raised is #63

#57 is up as a solution to a similar problem.

I want to avoid the error by checking the existence of the same.